### PR TITLE
make hash optional in URL regex

### DIFF
--- a/src/utils/object-url.ts
+++ b/src/utils/object-url.ts
@@ -1,7 +1,7 @@
 import { SquareCloudBlobError } from "../structures/error";
 
 const objectUrlRegex =
-	/^(?<url>https:\/\/public-blob\.squarecloud\.dev)?\/?(?<userId>[\w\d]+\/)(?<prefix>[\w\d\-_]+\/)?(?<name>[\w\d_]+)-(?<hash>[\w\d]+)(-ex\d+)?\.(?<extension>\w+)$/;
+	/^(?<url>https:\/\/public-blob\.squarecloud\.dev)?\/?(?<userId>[\w\d]+\/)(?<prefix>[\w\d\-_]+\/)?(?<name>[\w\d_]+)(?:-(?<hash>[\w\d]+))?(?:-ex\d+)?\.(?<extension>\w+)$/;
 
 /**
  * Parses the object URL to extract id, userId, prefix, name, hash and extension.


### PR DESCRIPTION
The `hash` segment is now optional.

Previously, object validation failed when the URL did not include a hash in its composition.

This PR updates the regex to correctly support URLs without a hash, preventing unnecessary validation errors and ensuring compatibility with all valid blob URL formats.
